### PR TITLE
modify "lichess account not linked" error message

### DIFF
--- a/src/bot/commands/account.rs
+++ b/src/bot/commands/account.rs
@@ -165,7 +165,7 @@ async fn rating(ctx: &Context, msg: &Message) -> CommandResult {
         }
         Ok(None) => {
             msg.channel_id.send_message(&ctx, |m| {
-                m.content("Couldn't find a lichess user associated with your account. Please use the `account` command first.");
+                m.content("Couldn't find a lichess user associated with your account. Please use the `ohnomy account` command first.");
                 m
             }).await?;
             Ok(())


### PR DESCRIPTION
to prevent https://discord.com/channels/421490568502181889/573664728639995945/885523157841235988 from happening again